### PR TITLE
blz 0.3.1

### DIFF
--- a/Formula/blz.rb
+++ b/Formula/blz.rb
@@ -1,0 +1,38 @@
+class Blz < Formula
+  desc "Fast local search for llms.txt"
+  homepage "https://blz.run"
+  license "Apache-2.0"
+  version "0.3.1"
+
+  livecheck do
+    url "https://github.com/outfitter-dev/blz/releases/latest"
+    strategy :github_latest
+  end
+
+  on_macos do
+    on_arm do
+      url "https://github.com/outfitter-dev/blz/releases/download/v#{version}/blz-#{version}-darwin-arm64.tar.gz"
+      sha256 "01f81b61d62d238315d8d492bdec8c54dd749dcd6bab24641ca9435cebd1126e"
+    end
+    on_intel do
+      url "https://github.com/outfitter-dev/blz/releases/download/v#{version}/blz-#{version}-darwin-x64.tar.gz"
+      sha256 "66d890585a3e23edd021ddf33e9bbc65fea2ece47cb8500f7c9151ded0ed24cb"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/outfitter-dev/blz/releases/download/v#{version}/blz-#{version}-linux-x64.tar.gz"
+      sha256 "c48b2d835fc6701989601602bd406dc8292f74c3c817d9779b3a9ff41eaaeac5"
+    end
+  end
+
+  def install
+    bin.install "blz"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/blz --version")
+    assert_match "blz", shell_output("#{bin}/blz --help")
+  end
+end


### PR DESCRIPTION
Bump blz formula to 0.3.1.
- arm64 sha256: 01f81b61d62d238315d8d492bdec8c54dd749dcd6bab24641ca9435cebd1126e
- x64   sha256: 66d890585a3e23edd021ddf33e9bbc65fea2ece47cb8500f7c9151ded0ed24cb
- linux sha256: c48b2d835fc6701989601602bd406dc8292f74c3c817d9779b3a9ff41eaaeac5