### PR TITLE
blz 1.0.0-beta.1

### DIFF
--- a/Formula/blz.rb
+++ b/Formula/blz.rb
@@ -1,0 +1,38 @@
+class Blz < Formula
+  desc "Fast local search for llms.txt"
+  homepage "https://blz.run"
+  license "Apache-2.0"
+  version "1.0.0-beta.1"
+
+  livecheck do
+    url "https://github.com/outfitter-dev/blz/releases/latest"
+    strategy :github_latest
+  end
+
+  on_macos do
+    on_arm do
+      url "https://github.com/outfitter-dev/blz/releases/download/v#{version}/blz-#{version}-darwin-arm64.tar.gz"
+      sha256 "f9069a590ac0e267e6caf987e5ac77c668328aaa6f93ba1a4c5615179c81b263"
+    end
+    on_intel do
+      url "https://github.com/outfitter-dev/blz/releases/download/v#{version}/blz-#{version}-darwin-x64.tar.gz"
+      sha256 "559e0e1296af9b918e44a23ad31a4e0214a84b89423e33b738d8bf6fd253b000"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/outfitter-dev/blz/releases/download/v#{version}/blz-#{version}-linux-x64.tar.gz"
+      sha256 "76d91c346713f6662b90f9d3fbfb5ab36722a1744cf25bf6ed4bb46efab071bb"
+    end
+  end
+
+  def install
+    bin.install "blz"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/blz --version")
+    assert_match "blz", shell_output("#{bin}/blz --help")
+  end
+end


### PR DESCRIPTION
Bump blz formula to 1.0.0-beta.1.
- arm64 sha256: f9069a590ac0e267e6caf987e5ac77c668328aaa6f93ba1a4c5615179c81b263
- x64   sha256: 559e0e1296af9b918e44a23ad31a4e0214a84b89423e33b738d8bf6fd253b000
- linux sha256: 76d91c346713f6662b90f9d3fbfb5ab36722a1744cf25bf6ed4bb46efab071bb