### PR TITLE
blz 1.5.3

### DIFF
--- a/Formula/blz.rb
+++ b/Formula/blz.rb
@@ -1,0 +1,45 @@
+class Blz < Formula
+  desc "Fast local search for llms.txt"
+  homepage "https://blz.run"
+  version "1.5.3"
+  license "Apache-2.0"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  on_macos do
+    on_arm do
+      url "https://github.com/outfitter-dev/blz/releases/download/v#{version}/blz-#{version}-darwin-arm64.tar.gz"
+      sha256 "10fb000689135ad94e3da27be3017226333b3a34d11981f8d5a09fbca6945662"
+    end
+    on_intel do
+      url "https://github.com/outfitter-dev/blz/releases/download/v#{version}/blz-#{version}-darwin-x64.tar.gz"
+      sha256 "bfa6da3c5ed45bd80d5a04e25564384bd93b998971cb4df1a281b197b5fb416f"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/outfitter-dev/blz/releases/download/v#{version}/blz-#{version}-linux-x64.tar.gz"
+      sha256 "67306af015627c0c32a6bc481734757072e26a2fddca01e5fb97d44614e177e7"
+    end
+    on_intel do
+      url "https://github.com/outfitter-dev/blz/releases/download/v#{version}/blz-#{version}-linux-x64.tar.gz"
+      sha256 "67306af015627c0c32a6bc481734757072e26a2fddca01e5fb97d44614e177e7"
+    end
+  end
+
+  def install
+    if OS.linux? && Hardware::CPU.arm?
+      odie "The blz Linux arm64 binary is not available yet. Please use the x86_64 build."
+    end
+    bin.install "blz"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/blz --version")
+    assert_match "blz", shell_output("#{bin}/blz --help")
+  end
+end


### PR DESCRIPTION
Bump blz formula to 1.5.3.
- arm64 sha256: 10fb000689135ad94e3da27be3017226333b3a34d11981f8d5a09fbca6945662
- x64   sha256: bfa6da3c5ed45bd80d5a04e25564384bd93b998971cb4df1a281b197b5fb416f
- linux sha256: 67306af015627c0c32a6bc481734757072e26a2fddca01e5fb97d44614e177e7