### PR TITLE
blz 1.5.4

### DIFF
--- a/Formula/blz.rb
+++ b/Formula/blz.rb
@@ -1,0 +1,45 @@
+class Blz < Formula
+  desc "Fast local search for llms.txt"
+  homepage "https://blz.run"
+  version "1.5.4"
+  license "Apache-2.0"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  on_macos do
+    on_arm do
+      url "https://github.com/outfitter-dev/blz/releases/download/v#{version}/blz-#{version}-darwin-arm64.tar.gz"
+      sha256 "117469d5047c88c3db27c97bc0214da05e977fd463abc8b77abbcb487ba66959"
+    end
+    on_intel do
+      url "https://github.com/outfitter-dev/blz/releases/download/v#{version}/blz-#{version}-darwin-x64.tar.gz"
+      sha256 "a5332d78aa1a89a49b7bdced4e3c2aa2c2b4d450c8d4d6682fed180ade7fbf01"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/outfitter-dev/blz/releases/download/v#{version}/blz-#{version}-linux-x64.tar.gz"
+      sha256 "b227ed0b6dea0e94d82aa8c17d5c3eb1f96c75f88eb3c89675af769628eb3208"
+    end
+    on_intel do
+      url "https://github.com/outfitter-dev/blz/releases/download/v#{version}/blz-#{version}-linux-x64.tar.gz"
+      sha256 "b227ed0b6dea0e94d82aa8c17d5c3eb1f96c75f88eb3c89675af769628eb3208"
+    end
+  end
+
+  def install
+    if OS.linux? && Hardware::CPU.arm?
+      odie "The blz Linux arm64 binary is not available yet. Please use the x86_64 build."
+    end
+    bin.install "blz"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/blz --version")
+    assert_match "blz", shell_output("#{bin}/blz --help")
+  end
+end


### PR DESCRIPTION
Bump blz formula to 1.5.4.
- arm64 sha256: 117469d5047c88c3db27c97bc0214da05e977fd463abc8b77abbcb487ba66959
- x64   sha256: a5332d78aa1a89a49b7bdced4e3c2aa2c2b4d450c8d4d6682fed180ade7fbf01
- linux sha256: b227ed0b6dea0e94d82aa8c17d5c3eb1f96c75f88eb3c89675af769628eb3208