### PR TITLE
chore(ci): drop macos-13 from test-bot

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-13, macos-15 ]
+        os: [ ubuntu-22.04, macos-15, macos-latest ]
     runs-on: ${{ matrix.os }}
     permissions:
       actions: read


### PR DESCRIPTION
## Summary
- remove macos-13 from the test-bot matrix to avoid retired runner failures
- keep macos-15 + macos-latest for intel/arm coverage

## Testing
- not run (workflow change)